### PR TITLE
fix create model returning 503 when no api key is supplied

### DIFF
--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -336,11 +336,15 @@ class SnapStoreAdmin(SnapPublisher):
 
         return self.process_response(response)
 
-    def create_store_model(self, session, store_id, name, api_key):
+    def create_store_model(self, session, store_id, name, api_key=None):
+        if api_key:
+            payload = {"name": name, "api-key": api_key, "series": "16"}
+        else:
+            payload = {"name": name, "series": "16"}
         response = self.session.post(
             url=self.get_publisherwg_endpoint_url(f"brand/{store_id}/model"),
             headers=self._get_publisherwg_authorization_header(session),
-            json={"name": name, "api-key": api_key, "series": "16"},
+            json=payload,
         )
 
         return self.process_response(response)
@@ -416,4 +420,4 @@ class SnapStoreAdmin(SnapPublisher):
             headers=headers,
         )
 
-        return self.process_response(response)
+        return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '4.3.0'
+version = '4.3.1'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
## DONE

- fix create model returning 503 when no api-key is supplied
- bump version