### PR TITLE
Fix reponse for revoke invites

### DIFF
--- a/canonicalwebteam/store_api/stores/charmstore.py
+++ b/canonicalwebteam/store_api/stores/charmstore.py
@@ -339,7 +339,7 @@ class CharmPublisher(Publisher):
             headers=self._get_authorization_header(publisher_auth),
             json=payload,
         )
-        return self.process_response(response)
+        return response
 
     def accept_invite(self, publisher_auth, name, token):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '4.8.0'
+version = '4.9.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
## Done
Fixed the response returned from the `revoke_invites` endpoint as it was hitting an exception every time