### PR TITLE
WIP Add create_track endpoint for Snapstore

### DIFF
--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -464,3 +464,14 @@ class SnapStoreAdmin(SnapPublisher):
         )
 
         return self.process_response(response)
+    
+    def create_track(self, publisher_auth, snap_name, track_name):
+        """
+        Create a track for a snap base on the snap's guardrail pattern.
+        """
+        response = self.session.post(
+            url=self.get_endpoint_url(f"snap/{snap_name}/tracks"),
+            headers=self._get_authorization_header(publisher_auth),
+            json=[{"name": track_name}],
+        )
+        return response


### PR DESCRIPTION
- Mirrors logic from [Charmstore](https://github.com/canonical/canonicalwebteam.store-api/blob/4447c53bacb90c156d554c4c18ead58401de2b9d/canonicalwebteam/store_api/stores/charmstore.py#L370) to add `create_track` endpoint for Snapstore. 
- https://api.charmhub.io/docs/default.html#create_tracks
- Part of [WD-9842](https://warthogs.atlassian.net/browse/WD-9842) so that I can test in Snapcraft.io repo.

[WD-9842]: https://warthogs.atlassian.net/browse/WD-9842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ