### PR TITLE
Add create_track endpoint

### DIFF
--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -215,18 +215,17 @@ class SnapPublisher(Publisher):
             json={"token": token},
         )
         return self.process_response(response)
-    
-    def create_track(self, publisher_auth, snap_name, track_name):
+
+    def create_track(self, session, snap_name, track_name):
         """
         Create a track for a snap base on the snap's guardrail pattern.
         """
         response = self.session.post(
             url=self.get_publisherwg_endpoint_url(f"snap/{snap_name}/tracks"),
-            headers=self._get_publisherwg_authorization_header(self.session),
+            headers=self._get_publisherwg_authorization_header(session),
             json=[{"name": track_name}],
         )
         return response
-
 
 
 class SnapStoreAdmin(SnapPublisher):

--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -215,6 +215,18 @@ class SnapPublisher(Publisher):
             json={"token": token},
         )
         return self.process_response(response)
+    
+    def create_track(self, publisher_auth, snap_name, track_name):
+        """
+        Create a track for a snap base on the snap's guardrail pattern.
+        """
+        response = self.session.post(
+            url=self.get_publisherwg_endpoint_url(f"snap/{snap_name}/tracks"),
+            headers=self._get_publisherwg_authorization_header(self.session),
+            json=[{"name": track_name}],
+        )
+        return response
+
 
 
 class SnapStoreAdmin(SnapPublisher):


### PR DESCRIPTION
## Done
Mirrors logic from Charmstore to query `create_track` endpoint, allowing users to create a new track for a given Snap.

Related PR: https://github.com/canonical/snapcraft.io/pull/4564

Fixes https://warthogs.atlassian.net/browse/WD-9842