### PR TITLE
Add delete package endpoint

### DIFF
--- a/canonicalwebteam/store_api/publisher.py
+++ b/canonicalwebteam/store_api/publisher.py
@@ -81,7 +81,7 @@ class Publisher:
             )
 
             return {
-                "Authorization": f"Macaroon root={root}, discharge={bound}"
+                "Authorization": f"macaroon root={root}, discharge={bound}"
             }
         # With Candid the header is Macaroons
         elif "macaroons" in session:

--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -227,6 +227,24 @@ class SnapPublisher(Publisher):
         )
         return response
 
+    def unregister_package_name(self, publisher_auth, snap_name):
+        """
+        Unregister a package name.
+
+        Args:
+            publisher_auth: Serialized macaroon to consume the API.
+            name: Name of the package to unregister
+        Returns:
+            The package name ID if successful
+            Otherwise, returns an error list
+        """
+        url = self.get_publisherwg_endpoint_url(f"snap/{snap_name}")
+        response = self.session.delete(
+            url=url,
+            headers=self._get_authorization_header(publisher_auth),
+        )
+        return response
+
 
 class SnapStoreAdmin(SnapPublisher):
     def get_endpoint_url(self, endpoint, api_version=2):


### PR DESCRIPTION
## Done
Verifies that the backend API endpoint works correctly to unregister a snap name
*Links to https://github.com/canonical/snapcraft.io/pull/4617*

## How to QA
Check video below where I use Postman to delete `abbie-global-test-snap-3`
(I will add the front-end in a different PR for proper testing)

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6772

## Video
[Screencast from 06-05-24 14:34:39.webm](https://github.com/canonical/snapcraft.io/assets/74302970/d4758495-9951-46d7-8b7b-af25232a0b5b)
