### PR TITLE
Bump minor version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '4.11.0'
+version = '4.11.1'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
Bumps minor version of StoreAPI repo to reflect changes for `unregister_package_name` (https://github.com/canonical/snapcraft.io/pull/4617 and https://github.com/canonical/canonicalwebteam.store-api/commit/2b35a35a7b1cdd01982057588401701554c4bd7c)