### PR TITLE
feat: adds `get_package_metadata` endpoint

### DIFF
--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -269,6 +269,24 @@ class SnapPublisher(Publisher):
         )
         return response
 
+    def get_package_metadata(self, publisher_auth, package_type, snap_name):
+        """
+        Get general metadata for a package.
+        Args:
+            publisher_auth: Serialized macaroon to consume the API.
+            package_type: Type of packages to obtain.
+        Returns:
+            Package general metadata
+        """
+        response = self.session.get(
+            url=self.get_publisherwg_endpoint_url(
+                f"{package_type}/{snap_name}"
+            ),
+            headers=self._get_publisherwg_authorization_header(publisher_auth),
+        )
+
+        return self.process_response(response)["metadata"]
+
     def unregister_package_name(self, publisher_auth, snap_name):
         """
         Unregister a package name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '4.11.2'
+version = '4.11.3'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
- Adds `get_package_metadata` endpoint to be able to query for a snap's track guardrails. See screenshots below of local testing with Postman.
- Bumps minor version
- PR to follow with corresponding endpoint in Snapcraft.io

Snap with track guardrails
![tcg](https://github.com/canonical/canonicalwebteam.store-api/assets/74302970/9aadbce0-2164-4a4e-8bbe-4b4ed872cd05)

Snap without track guardrails
![no tcg](https://github.com/canonical/canonicalwebteam.store-api/assets/74302970/5ff6cc13-a53d-47ab-8831-4945fc9a9124)