### PR TITLE
fix: change return value from package_metadata endpoint

### DIFF
--- a/canonicalwebteam/store_api/stores/snapstore.py
+++ b/canonicalwebteam/store_api/stores/snapstore.py
@@ -272,6 +272,9 @@ class SnapPublisher(Publisher):
     def get_package_metadata(self, publisher_auth, package_type, snap_name):
         """
         Get general metadata for a package.
+        Documentation:
+            https://api.charmhub.io/docs/default.html#package_metadata
+        Endpoint: [GET] https://api.charmhub.io/v1/{package_type}/{snap_name}
         Args:
             publisher_auth: Serialized macaroon to consume the API.
             package_type: Type of packages to obtain.
@@ -284,8 +287,7 @@ class SnapPublisher(Publisher):
             ),
             headers=self._get_publisherwg_authorization_header(publisher_auth),
         )
-
-        return self.process_response(response)["metadata"]
+        return response.json()
 
     def unregister_package_name(self, publisher_auth, snap_name):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '4.12.0'
+version = '4.12.2'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'


### PR DESCRIPTION
## Done
Updates return value from `get_package_metadata` endpoint as we do not want to query for ["metadata"] here. This will make error handling easier on the snapcraft.io side.