### PR TITLE
WD-22111 Retrieve account keys

### DIFF
--- a/canonicalwebteam/store_api/dashboard.py
+++ b/canonicalwebteam/store_api/dashboard.py
@@ -80,6 +80,15 @@ class Dashboard(Base):
         )
         return self.process_response(response)
 
+    def get_account_keys(self, session: dict) -> dict:
+        """
+        Returns the keys associated with a user account
+        Documentation:
+            https://dashboard.snapcraft.io/docs/reference/v1/account.html#get--dev-api-account
+        Endpoint: [GET] https://dashboard.snapcraft.io/dev/api/account
+        """
+        return self.get_account(session).get("account-keys", {})
+
     def get_account_snaps(self, session: dict) -> dict:
         """
         Returns the snaps associated with a user account

--- a/canonicalwebteam/store_api/dashboard.py
+++ b/canonicalwebteam/store_api/dashboard.py
@@ -80,14 +80,14 @@ class Dashboard(Base):
         )
         return self.process_response(response)
 
-    def get_account_keys(self, session: dict) -> dict:
+    def get_account_keys(self, session: dict) -> list:
         """
         Returns the keys associated with a user account
         Documentation:
             https://dashboard.snapcraft.io/docs/reference/v1/account.html#get--dev-api-account
         Endpoint: [GET] https://dashboard.snapcraft.io/dev/api/account
         """
-        return self.get_account(session).get("account-keys", {})
+        return self.get_account(session).get("account-keys", [])
 
     def get_account_snaps(self, session: dict) -> dict:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '6.2.0'
+version = '6.3.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/DashboardTest.test_get_account_keys.yaml
+++ b/tests/cassettes/DashboardTest.test_get_account_keys.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://dashboard.snapcraft.io/dev/api/account
+  response:
+    body:
+      string: '{"id": "test_id", "display-name": "Eduard
+        Daniel Manta", "username": "edisile", "email": "eduard.manta@canonical.com",
+        "validation": "unproven", "account-keys": [{"name": "test", "public-key-sha3-384":
+        "****************************************************************", "since":
+        "2025-05-14T13:29:49Z"}, {"name": "test3", "public-key-sha3-384": "****************************************************************",
+        "since": "2025-05-23T09:57:47Z"}, {"name": "test2", "public-key-sha3-384":
+        "****************************************************************", "since":
+        "2025-05-21T11:54:39Z"}], "snaps": {"16":{}},
+        "short_namespace": "edisile"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Date:
+      - Fri, 23 May 2025 12:38:45 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - gunicorn
+      Strict-Transport-Security:
+      - max-age=2592000
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=0, no-cache, no-store, must-revalidate, private
+      content-language:
+      - en
+      content-length:
+      - '1834'
+      content-type:
+      - application/json
+      expires:
+      - Fri, 23 May 2025 12:38:45 GMT
+      vary:
+      - Authorization,Accept-Language
+      via:
+      - 1.1 juju-5214c0-prod-scasnap-486 (squid/3.5.27)
+      x-cache:
+      - MISS from juju-5214c0-prod-scasnap-486
+      x-cache-lookup:
+      - MISS from juju-5214c0-prod-scasnap-486:3128
+      x-request-id:
+      - aDBsVDx0qogN38KyaejRywAAAXU1
+      x-vcs-revision:
+      - b161d9872c
+      x-view-name:
+      - api-account-info
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -32,6 +32,7 @@ class DashboardTest(VCRTestCase):
         keys = self.client.get_account_keys(test_session)
         self.assertIsInstance(keys, list)
         for k in keys:
+            self.assertIsInstance(k, dict)
             self.assertIn("name", k)
             self.assertIn("public-key-sha3-384", k)
             self.assertIn("since", k)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -26,6 +26,7 @@ class DashboardTest(VCRTestCase):
         self.assertIsInstance(account, dict)
         self.assertEqual(account["username"], "codeempress")
         self.assertIn("snaps", account)
+        self.assertIn("account-keys", account)
 
     def test_get_agreement(self):
         agreement = self.client.get_agreement(test_session)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -28,6 +28,14 @@ class DashboardTest(VCRTestCase):
         self.assertIn("snaps", account)
         self.assertIn("account-keys", account)
 
+    def test_get_account_keys(self):
+        keys = self.client.get_account_keys(test_session)
+        self.assertIsInstance(keys, list)
+        for k in keys:
+            self.assertIn("name", k)
+            self.assertIn("public-key-sha3-384", k)
+            self.assertIn("since", k)
+
     def test_get_agreement(self):
         agreement = self.client.get_agreement(test_session)
         self.assertIsInstance(agreement, dict)


### PR DESCRIPTION
Add a new endpoint to get the list of account keys of the current logged in user from their account information object