### PR TITLE
fix: updated error handling

### DIFF
--- a/canonicalwebteam/store_api/base.py
+++ b/canonicalwebteam/store_api/base.py
@@ -53,7 +53,7 @@ class Base:
                     response.status_code,
                     error_list,
                 )
-            elif not body:
+            else:
                 raise StoreApiResponseError(
                     "Unknown error from api", response.status_code
                 )

--- a/canonicalwebteam/store_api/publishergw.py
+++ b/canonicalwebteam/store_api/publishergw.py
@@ -243,10 +243,14 @@ class PublisherGW(Base):
             headers=self._get_dev_token_authorization_header(session),
         )
 
-        if response.status_code == 404:
-            return self.process_response(response)
+        processed_response = self.process_response(response)
 
-        return self.process_response(response)["metadata"]
+        if "metadata" not in processed_response:
+            raise KeyError("Missing 'metadata' key in response")
+
+        return processed_response["metadata"]
+            
+
 
     def update_package_metadata(
         self, publisher_auth: str, package_type: str, name: str, data: dict


### PR DESCRIPTION
- when sending request to api, it returns error and also has body.  The else statement's condition is deleted so the status code can be sent to the caller. 
Example: 
Error code: 401
```{'Code': 'macaroon discharge required', 'Message': 'discharge required', 'Info': {....}}```

- raised an error if "metadata" entry doesn't exist in the response.