### PR TITLE
WD-24093 Retry and backoff utilities

### DIFF
--- a/canonicalwebteam/exceptions.py
+++ b/canonicalwebteam/exceptions.py
@@ -14,6 +14,46 @@ class StoreApiConnectionError(StoreApiError):
     pass
 
 
+class StoreApiInternalError(StoreApiConnectionError):
+    """
+    Store API internal error
+    """
+
+    pass
+
+
+class StoreApiNotImplementedError(StoreApiConnectionError):
+    """
+    Store API doesn't implement this method
+    """
+
+    pass
+
+
+class StoreApiBadGatewayError(StoreApiConnectionError):
+    """
+    Got and invalid response from Store API
+    """
+
+    pass
+
+
+class StoreApiServiceUnavailableError(StoreApiConnectionError):
+    """
+    Store API is not available
+    """
+
+    pass
+
+
+class StoreApiGatewayTimeoutError(StoreApiConnectionError):
+    """
+    Request to Store API timed out
+    """
+
+    pass
+
+
 class StoreApiResourceNotFound(StoreApiError):
     """
     The requested resource is not found

--- a/canonicalwebteam/retry_utils.py
+++ b/canonicalwebteam/retry_utils.py
@@ -1,0 +1,150 @@
+from typing import Callable, List, Tuple, Type, TypeVar
+from random import random
+from time import sleep
+from sys import maxsize as MAX_INT
+import functools
+
+
+P = TypeVar('P')
+R = TypeVar('R')
+
+
+def retry(func: Callable[P, R] = None, *,
+          limit: int = MAX_INT,
+          delay_fn: Callable[[int], float] = (lambda x: 0.0),
+          sleep_fn: Callable[[float], None] = (lambda x: None),
+          callback_fn: Callable[[Exception], bool] = (lambda x: False),
+          logger_fn: Callable[[str], None] = (lambda x: None),
+          exceptions: Tuple[Type[Exception]] = (Exception)) -> Callable[P, R]:
+    """
+    Decorator that implements retry logic for `func` when any of the
+    Exceptions in `exceptions` happen.
+
+    Arguments:
+    func: function what will be retried
+
+    Keyword arguments:
+    limit: max number of retry attempts
+    exceptions: tuple containing the types of exceptions we can catch and
+        that trigger a retry
+    callback_fn: function that takes as argument an exception caught a during
+        the retry loop, it should return a bool indicating whether to abort 
+        the loop or not; it will be called every time a member of `exceptions`
+        is caught
+    logger_fn: function that logs errors caught and not propagated during
+        the retry loop; it will be called every time a member of `exceptions`
+        is caught
+    delay_fn: function that takes the current attempt as an argument and
+        returns a float indicating the delay in seconds before calling `func`
+        again
+    sleep_fn: function that takes a float indicating a delay in seconds and
+        waits for this specified time before executing `func` again; it's
+        user's responsibility to make sure the sleep function is appropriate
+        for their usage (e.g. use an async sleep in and async environment)
+    """
+
+    if func is None:
+        # if this decorator is applied using the @ syntax, `func` will not
+        # be defined correctly, so we must do a partial application to wrap
+        # `func` correctly
+        return functools.partial(retry,
+                                 limit=limit,
+                                 delay_fn=delay_fn,
+                                 sleep_fn=sleep_fn,
+                                 callback_fn=callback_fn,
+                                 logger_fn=logger_fn,
+                                 exceptions=exceptions)
+
+    if limit <= 0:
+        raise ValueError("The limit must be at least 1")
+
+    @functools.wraps(func)
+    def _retry(*args, **kwargs):
+        retry_attempts = 0
+        last_exception = None
+
+        while retry_attempts < limit:
+            if (retry_attempts > 0):
+                # only sleep if we've already tried once
+                sleep_fn(delay_fn(retry_attempts))
+
+            try:
+                return func(*args, **kwargs)
+            except exceptions as e:
+                last_exception = e
+                retry_attempts += 1
+
+                if callback_fn(e):
+                    # stop early if callback says so, raise `e` immediately
+                    raise e
+
+                logger_fn(
+                    f"@retry ({retry_attempts}/{limit}) `{func.__name__}`: {e}")
+
+        # if we made it here, it means we ran the loop and couldn't get a
+        # clean run, raise the last exception we caught and let the user
+        # deal with it
+        raise last_exception
+
+    return _retry
+
+
+def delay_random(min: float, max: float):
+    """
+    Returns a function that picks a random delay between `min` and `max`
+    """
+    if min < 0:
+        raise ValueError("The minimum delay must be at least 0")
+    if max <= min:
+        raise ValueError("The maximum delay must be greater than the minimum")
+
+    def _delay_random(_: int):
+        return min + random() * (max - min)
+
+    return _delay_random
+
+
+def delay_exponential(delay_mult: float, exp_base: float, max_delay: float = float('inf')):
+    """
+    Returns a function that implements an exponential backoff with an upper
+    limit based on the number of attempts made `n`, according to the following
+    formula:
+        min(`max_delay`, `delay_mult` * `exp_base`^`n`)
+    """
+    if delay_mult <= 0:
+        raise ValueError("The delay multiplier must be greater than 0")
+    if exp_base <= 1:
+        raise ValueError("The exponential base must be greater than 1")
+    if max_delay <= 0:
+        raise ValueError("The maximum delay must be greater than 0")
+
+    def _delay_exponential(attempt: int):
+        return min(max_delay, delay_mult * (exp_base ** attempt))
+
+    return _delay_exponential
+
+
+"""
+Example usage:
+
+    @retry(
+        limit=5,
+        logger_fn=print,
+        exceptions=(TypeError),
+        sleep_fn=sleep,
+        delay_fn=delay_exponential(1, 2)
+    )
+    def test_fn(val: int):
+        return None + val  # this will raise TypeError
+
+    try:
+        test_fn(2)
+    except TypeError as e:
+        print(e)
+
+This will attempt to run `test_fn` 5 times, will catch TypeError 4 times and
+then it will let the exception propagate after executing the function for the
+last time. Each time, it will take an exponentially longer amount of time to
+run, making the total execution time around 30s (plus some small random delay
+caused by the OS).
+"""

--- a/canonicalwebteam/store_api/base.py
+++ b/canonicalwebteam/store_api/base.py
@@ -1,12 +1,17 @@
 from canonicalwebteam.exceptions import (
+    PublisherAgreementNotSigned,
+    PublisherMacaroonRefreshRequired,
+    PublisherMissingUsername,
+    StoreApiBadGatewayError,
     StoreApiConnectionError,
+    StoreApiGatewayTimeoutError,
+    StoreApiInternalError,
+    StoreApiNotImplementedError,
     StoreApiResourceNotFound,
     StoreApiResponseDecodeError,
     StoreApiResponseError,
     StoreApiResponseErrorList,
-    PublisherAgreementNotSigned,
-    PublisherMacaroonRefreshRequired,
-    PublisherMissingUsername,
+    StoreApiServiceUnavailableError,
 )
 
 
@@ -17,7 +22,25 @@ class Base:
     def process_response(self, response):
         # 5xx responses are not in JSON format
         if response.status_code >= 500:
-            raise StoreApiConnectionError("Service Unavailable")
+            match response.status_code:
+                case 500:
+                    raise StoreApiInternalError(
+                        "Internal error upstream")
+                case 501:
+                    raise StoreApiNotImplementedError(
+                        "Service doesn't implement this method")
+                case 502:
+                    raise StoreApiBadGatewayError(
+                        "Invalid response from upstream")
+                case 503:
+                    raise StoreApiServiceUnavailableError(
+                        "Service is unavailable")
+                case 504:
+                    raise StoreApiGatewayTimeoutError(
+                        "Upstream request timed out")
+                case _:
+                    raise StoreApiConnectionError(
+                        f"Service unavailable, code {response.status_code}")
 
         try:
             body = response.json()

--- a/tests/test_retry_decorator.py
+++ b/tests/test_retry_decorator.py
@@ -1,0 +1,151 @@
+from os import getenv
+from typing import Type
+from vcr_unittest import VCRTestCase
+from canonicalwebteam.retry_utils import retry
+
+
+def raise_exception(E: Type[Exception]):
+    raise E("Exception")
+
+
+LIMIT = 5
+
+
+class Counter:
+    """
+    Simple class that implements a counter
+    """
+
+    def __init__(self, n: int = 0):
+        self.counter = n
+
+    def increment(self, *args):
+        self.counter = self.counter + 1
+
+
+class RetryDecoratorTest(VCRTestCase):
+    def test_no_exception(self):
+        @retry()
+        def noop():
+            pass
+
+        noop()  # this should never trigger an exception
+
+    def test_callback_fn(self):
+        def callback(e: Exception):
+            self.assertIsInstance(e, TypeError)
+
+        @retry(
+            limit=LIMIT,
+            callback_fn=callback
+        )
+        def wrapper():
+            raise Exception("Exception")
+
+        with self.assertRaises(Exception):
+            # last execution will raise Exception
+            wrapper()
+
+    def test_logger_fn(self):
+        def logger(e: str):
+            self.assertIsInstance(e, str)
+            self.assertTrue(e.startswith("@retry"))
+
+        @retry(
+            limit=LIMIT,
+            logger_fn=logger
+        )
+        def wrapper():
+            raise Exception("Exception")
+
+        with self.assertRaises(Exception):
+            # last execution will raise Exception
+            wrapper()
+
+    def test_retry_limit(self):
+        c = Counter()
+
+        @retry(
+            limit=LIMIT,
+            callback_fn=c.increment
+        )
+        def wrapper():
+            raise Exception("Exception")
+
+        with self.assertRaises(Exception):
+            # last execution will raise Exception
+            wrapper()
+
+        self.assertEqual(c.counter, LIMIT)
+
+    def test_good_exception_match(self):
+        c = Counter()
+
+        @retry(
+            limit=LIMIT,
+            callback_fn=c.increment,
+            exceptions=(TypeError)
+        )
+        def wrapper():
+            raise TypeError("Exception")
+
+        with self.assertRaises(TypeError):
+            # last execution will raise TypeError
+            wrapper()
+
+        self.assertEqual(c.counter, LIMIT)
+
+    def test_bad_exception_match(self):
+        @retry(
+            limit=LIMIT,
+            exceptions=(TypeError)
+        )
+        def wrapper():
+            raise ValueError("Exception")
+
+        with self.assertRaises(ValueError):
+            # exception types don't match so ValueError is propagated
+            wrapper()
+
+    def test_delay_fn(self):
+        c = Counter(1)
+
+        def delay(x: int):
+            self.assertEqual(x, c.counter)
+            c.increment()
+            return 0.0
+
+        @retry(
+            limit=LIMIT,
+            delay_fn=delay,
+            exceptions=(TypeError)
+        )
+        def wrapper():
+            raise Exception("Exception")
+
+        with self.assertRaises(Exception):
+            # last execution will raise TypeError
+            wrapper()
+
+    def test_sleep_fn(self):
+        c = Counter()
+
+        def sleep(x: float):
+            c.increment()
+            self.assertEqual(x, float(c.counter))
+
+        @retry(
+            limit=LIMIT,
+            exceptions=(Exception),
+            delay_fn=(lambda x: float(x)),
+            sleep_fn=sleep
+        )
+        def wrapper():
+            raise Exception("Exception")
+
+        with self.assertRaises(Exception):
+            # last execution will raise TypeError
+            wrapper()
+
+        # sleep only happens *between* calls
+        self.assertEqual(c.counter, LIMIT - 1)


### PR DESCRIPTION
## Retry and backoff utilities

- added a decorator that can be applied to a function or method to allow multiple executions in case of exceptions; the decorator supports the following features
    - limit: max number of attempts before propagating the last error
    - filtering by exception type: users can specify which exceptions are expected to be caught, those that don't match get propagated
    - early exit via callback: a callback function can inspect each exception and decide whether to quit the retry loop early
    - configurable sleep: users can define their own sleep implementation
    - configurable delay: a function can decide how long each retry is 
- added some utilities for standard delay implementations (random within a range and exponential)
- added tests for this decorator
- extended the Exception hierarchy to better track different 5XX errors coming from the Store API