### PR TITLE
WD-17150 - Add endpoint for snap_details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ celerybeat-schedule
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Editors
+.vscode/

--- a/canonicalwebteam/store_api/devicegw.py
+++ b/canonicalwebteam/store_api/devicegw.py
@@ -228,6 +228,34 @@ class DeviceGW(Base):
             headers=headers,
         )
         return self.process_response(response)
+    
+    def get_snap_details(
+        self,
+        name: str,
+        channel: Optional[str] = None,
+        fields: list = [],
+    ) -> dict:
+        """
+        Documentation: https://api.snapcraft.io/docs/details.html#snap_details
+        Endpoint: [GET]
+            https://api.snapcraft.io/api/v1/{name_space}/details/{package_name}
+        """
+        # this method is only available in API version 1
+        api_version = 1
+        url = self.get_endpoint_url("details/" + name, api_version=api_version)
+        params = {}
+        if fields:
+            params = {"fields": ",".join(fields)}
+        if channel:
+            params["channel"] = channel
+        headers = self.config[api_version].get("headers")
+
+        response = self.session.get(
+            url,
+            params=params,
+            headers=headers,
+        )
+        return self.process_response(response)
 
     def get_public_metrics(self, json: dict, api_version: int = 1) -> dict:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'canonicalwebteam.store-api'
-version = '6.8.1'
+version = '6.9.0'
 description = ''
 authors = ['Canonical Web Team <webteam@canonical.com>']
 license = 'LGPL-3.0'

--- a/tests/cassettes/DeviceGWTest.test_get_snap_details.yaml
+++ b/tests/cassettes/DeviceGWTest.test_get_snap_details.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Snap-Device-Series:
+      - '16'
+      X-Ubuntu-Series:
+      - '16'
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://api.snapcraft.io/api/v1/snaps/details/nushell?fields=name%2Caliases
+  response:
+    body:
+      string: |
+        {
+          "aliases": [
+            { "name": "nu", "target": "nu" },
+            {
+              "name": "nu_plugin_stress_internals",
+              "target": "nu-plugin-stress-internals"
+            },
+            { "name": "nu_plugin_gstat", "target": "nu-plugin-gstat" },
+            { "name": "nu_plugin_formats", "target": "nu-plugin-formats" },
+            { "name": "nu_plugin_polars", "target": "nu-plugin-polars" },
+            { "name": "nu_plugin_query", "target": "nu-plugin-query" },
+            { "name": "nu_plugin_inc", "target": "nu-plugin-inc" },
+            { "name": "nu_plugin_example", "target": "nu-plugin-example" },
+            { "name": "nu_plugin_custom_values", "target": "nu-plugin-custom-values" }
+          ],
+          "name": "nushell.sed-i",
+          "package_name": "nushell"
+        }
+    headers:
+      content-length:
+      - '687'
+      content-type:
+      - application/json
+      date:
+      - Wed, 3 Sep 2025 09:44:24 GMT
+      server:
+      - gunicorn
+      snap-store-version:
+      - '69'
+      x-request-id:
+      - 00000000000000000000FFFF0AACCA2CE9A000000000000000000000FFFF0A8325F001BB68B81A1AE667B51D
+      x-vcs-revision:
+      - cd12ae9598aebd93b8b720cd2681b669c61bd790
+      x-view-name:
+      - snapdevicegw.webapi_details.snap_details
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_device_gateway.py
+++ b/tests/test_device_gateway.py
@@ -66,6 +66,17 @@ class DeviceGWTest(VCRTestCase):
         self.assertIsInstance(response, dict)
         self.assertEqual(response["name"], "test-lukewh")
 
+    def test_get_snap_details(self):
+        response = self.client.get_snap_details(
+            name="nushell",
+            fields=["name", "aliases"],
+        )
+        self.assertIsInstance(response, dict)
+        self.assertEqual(response["name"], "nushell.sed-i")
+        self.assertEqual(response["package_name"], "nushell")
+        self.assertIsInstance(response["aliases"], list)
+        self.assertEqual(len(response["aliases"]), 9)
+
     def test_get_categories(self):
         response = self.client.get_categories()
         self.assertIsInstance(response, dict)


### PR DESCRIPTION
## Done

Add endpoint for [snap_details](https://api.snapcraft.io/docs/details.html#snap_details).
Add test for endpoint.

## Screenshot

<img width="1470" height="956" alt="Screenshot 2025-09-03 at 17 13 21" src="https://github.com/user-attachments/assets/766a8588-54e1-49d8-b441-9a17b982b37b" />

New endpoint being used in snapcraft.io. Code for the functionality is still in development.