### PR TITLE
fix: use correct env var name

### DIFF
--- a/canonicalwebteam/store_api/dashboard.py
+++ b/canonicalwebteam/store_api/dashboard.py
@@ -10,7 +10,7 @@ from canonicalwebteam.exceptions import (
 
 
 DASHBOARD_API_URL = getenv(
-    "DASHBOARD_API_URL", "https://dashboard.snapcraft.io/"
+    "SNAPSTORE_DASHBOARD_API_URL", "https://dashboard.snapcraft.io/"
 )
 
 


### PR DESCRIPTION
The snapcraft.io app and this package use two different env var names to refer to the same concept: snapcraft.io uses `SNAPSTORE_DASHBOARD_API_URL` and this package uses `DASHBOARD_API_URL`, both indicate the base URL of the Snap Store dashboard. This leads to issues where setting one but not the other breaks the login flow

This is how snapcraft.io uses this env var: https://github.com/canonical/snapcraft.io/blob/f6a332c6151bbed8e1d249ed4281ff601c9eb36c/webapp/api/sso.py#L7

This PR updates the env var name to the one used by snapcraft.io so we don't have to deal with setting both of them
